### PR TITLE
[codex] Support Lua-style syntax comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ code = ''
 '';
 ```
 
-### Pattern 4: Lua-style comment `-- syntax:` (inside string)
+### Pattern 4: Double-dash comment `-- syntax:` (inside string)
 
-For languages where `--` is a comment:
+For languages where `--` is a valid comment, such as Lua and SQL:
 
 ```nix
 initLua = ''

--- a/README.md
+++ b/README.md
@@ -50,7 +50,20 @@ code = ''
 '';
 ```
 
-### Pattern 4: Comment before string (for JSON, etc.)
+### Pattern 4: Lua-style comment `-- syntax:` (inside string)
+
+For languages where `--` is a comment:
+
+```nix
+initLua = ''
+  -- syntax: lua
+  function greet(name)
+    print("Hello, " .. name)
+  end
+'';
+```
+
+### Pattern 5: Comment before string (for JSON, etc.)
 
 For languages without comments (like JSON), place the marker BEFORE the string as a Nix comment:
 

--- a/src/injection-grammar.ts
+++ b/src/injection-grammar.ts
@@ -110,6 +110,7 @@ export class InjectionGrammar {
    * - `# lang` (short form)
    * - `# syntax: lang` (explicit form with # comment)
    * - `// syntax: lang` (explicit form with // comment)
+   * - `-- syntax: lang` (explicit form with -- comment)
    */
   private getInsideStringPatterns() {
     const entries = Object.entries(this.languages);
@@ -150,6 +151,18 @@ export class InjectionGrammar {
         begin: `^\\s*//\\s*syntax:\\s*${idPattern}\\s*$`,
         beginCaptures: {
           "0": { name: "comment.line.double-slash meta.embedded.hint" },
+        },
+        while: "^(?!\\s*''(?!'))",
+        contentName: `meta.embedded.block.${primaryId}`,
+        patterns: [{ include: scopeName }],
+      });
+
+      // -- syntax: lang (Lua-style comment)
+      patterns.push({
+        comment: `Match -- syntax: ${primaryId} inside multiline string`,
+        begin: `^\\s*--\\s*syntax:\\s*${idPattern}\\s*$`,
+        beginCaptures: {
+          "0": { name: "comment.line.double-dash meta.embedded.hint" },
         },
         while: "^(?!\\s*''(?!'))",
         contentName: `meta.embedded.block.${primaryId}`,

--- a/src/injection-grammar.ts
+++ b/src/injection-grammar.ts
@@ -7,6 +7,8 @@ export type LanguageConfig = {
 
 export type LanguagesMap = Record<string, string | LanguageConfig>;
 
+const DOUBLE_DASH_COMMENT_LANGUAGE_IDS = new Set(["lua", "sql"]);
+
 /**
  * TextMate injection grammar for embedded languages inside Nix multi-line strings.
  *
@@ -120,6 +122,7 @@ export class InjectionGrammar {
       const scopeName = typeof config === "string" ? config : config.scopeName;
       const idPattern = id.includes("|") ? `(?:${id})` : id;
       const primaryId = id.split("|")[0];
+      const aliases = id.split("|");
 
       // # lang (short form - backward compatible)
       patterns.push({
@@ -157,17 +160,21 @@ export class InjectionGrammar {
         patterns: [{ include: scopeName }],
       });
 
-      // -- syntax: lang (Lua-style comment)
-      patterns.push({
-        comment: `Match -- syntax: ${primaryId} inside multiline string`,
-        begin: `^\\s*--\\s*syntax:\\s*${idPattern}\\s*$`,
-        beginCaptures: {
-          "0": { name: "comment.line.double-dash meta.embedded.hint" },
-        },
-        while: "^(?!\\s*''(?!'))",
-        contentName: `meta.embedded.block.${primaryId}`,
-        patterns: [{ include: scopeName }],
-      });
+      if (
+        aliases.some((alias) => DOUBLE_DASH_COMMENT_LANGUAGE_IDS.has(alias))
+      ) {
+        // -- syntax: lang (Lua/SQL-style comment)
+        patterns.push({
+          comment: `Match -- syntax: ${primaryId} inside multiline string`,
+          begin: `^\\s*--\\s*syntax:\\s*${idPattern}\\s*$`,
+          beginCaptures: {
+            "0": { name: "comment.line.double-dash meta.embedded.hint" },
+          },
+          while: "^(?!\\s*''(?!'))",
+          contentName: `meta.embedded.block.${primaryId}`,
+          patterns: [{ include: scopeName }],
+        });
+      }
     });
 
     return patterns;

--- a/syntaxes/source.nix.injection.tmLanguage.json
+++ b/syntaxes/source.nix.injection.tmLanguage.json
@@ -51,22 +51,6 @@
       ]
     },
     {
-      "comment": "Match -- syntax: shell inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*(?:shell|bash|sh)\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.shell",
-      "patterns": [
-        {
-          "include": "source.shell"
-        }
-      ]
-    },
-    {
       "comment": "Match # python inside multiline string",
       "begin": "^\\s*#\\s*(?:python|py)\\s*$",
       "beginCaptures": {
@@ -104,22 +88,6 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.python",
-      "patterns": [
-        {
-          "include": "source.python"
-        }
-      ]
-    },
-    {
-      "comment": "Match -- syntax: python inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*(?:python|py)\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -179,22 +147,6 @@
       ]
     },
     {
-      "comment": "Match -- syntax: javascript inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*(?:javascript|js)\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.javascript",
-      "patterns": [
-        {
-          "include": "source.js"
-        }
-      ]
-    },
-    {
       "comment": "Match # typescript inside multiline string",
       "begin": "^\\s*#\\s*(?:typescript|ts)\\s*$",
       "beginCaptures": {
@@ -232,22 +184,6 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.typescript",
-      "patterns": [
-        {
-          "include": "source.ts"
-        }
-      ]
-    },
-    {
-      "comment": "Match -- syntax: typescript inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*(?:typescript|ts)\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -307,22 +243,6 @@
       ]
     },
     {
-      "comment": "Match -- syntax: json inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*json\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.json",
-      "patterns": [
-        {
-          "include": "source.json"
-        }
-      ]
-    },
-    {
       "comment": "Match # yaml inside multiline string",
       "begin": "^\\s*#\\s*yaml\\s*$",
       "beginCaptures": {
@@ -360,22 +280,6 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.yaml",
-      "patterns": [
-        {
-          "include": "source.yaml"
-        }
-      ]
-    },
-    {
-      "comment": "Match -- syntax: yaml inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*yaml\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -563,22 +467,6 @@
       ]
     },
     {
-      "comment": "Match -- syntax: ruby inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*ruby\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.ruby",
-      "patterns": [
-        {
-          "include": "source.ruby"
-        }
-      ]
-    },
-    {
       "comment": "Match # rust inside multiline string",
       "begin": "^\\s*#\\s*rust\\s*$",
       "beginCaptures": {
@@ -616,22 +504,6 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.rust",
-      "patterns": [
-        {
-          "include": "source.rust"
-        }
-      ]
-    },
-    {
-      "comment": "Match -- syntax: rust inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*rust\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -691,22 +563,6 @@
       ]
     },
     {
-      "comment": "Match -- syntax: go inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*go\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.go",
-      "patterns": [
-        {
-          "include": "source.go"
-        }
-      ]
-    },
-    {
       "comment": "Match # html inside multiline string",
       "begin": "^\\s*#\\s*html\\s*$",
       "beginCaptures": {
@@ -744,22 +600,6 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.html",
-      "patterns": [
-        {
-          "include": "text.html.derivative"
-        }
-      ]
-    },
-    {
-      "comment": "Match -- syntax: html inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*html\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -819,22 +659,6 @@
       ]
     },
     {
-      "comment": "Match -- syntax: css inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*css\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.css",
-      "patterns": [
-        {
-          "include": "source.css"
-        }
-      ]
-    },
-    {
       "comment": "Match # nix inside multiline string",
       "begin": "^\\s*#\\s*nix\\s*$",
       "beginCaptures": {
@@ -872,22 +696,6 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
-        }
-      },
-      "while": "^(?!\\s*''(?!'))",
-      "contentName": "meta.embedded.block.nix",
-      "patterns": [
-        {
-          "include": "source.nix"
-        }
-      ]
-    },
-    {
-      "comment": "Match -- syntax: nix inside multiline string",
-      "begin": "^\\s*--\\s*syntax:\\s*nix\\s*$",
-      "beginCaptures": {
-        "0": {
-          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",

--- a/syntaxes/source.nix.injection.tmLanguage.json
+++ b/syntaxes/source.nix.injection.tmLanguage.json
@@ -51,6 +51,22 @@
       ]
     },
     {
+      "comment": "Match -- syntax: shell inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*(?:shell|bash|sh)\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
       "comment": "Match # python inside multiline string",
       "begin": "^\\s*#\\s*(?:python|py)\\s*$",
       "beginCaptures": {
@@ -88,6 +104,22 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.python",
+      "patterns": [
+        {
+          "include": "source.python"
+        }
+      ]
+    },
+    {
+      "comment": "Match -- syntax: python inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*(?:python|py)\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -147,6 +179,22 @@
       ]
     },
     {
+      "comment": "Match -- syntax: javascript inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*(?:javascript|js)\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.javascript",
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ]
+    },
+    {
       "comment": "Match # typescript inside multiline string",
       "begin": "^\\s*#\\s*(?:typescript|ts)\\s*$",
       "beginCaptures": {
@@ -184,6 +232,22 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.typescript",
+      "patterns": [
+        {
+          "include": "source.ts"
+        }
+      ]
+    },
+    {
+      "comment": "Match -- syntax: typescript inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*(?:typescript|ts)\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -243,6 +307,22 @@
       ]
     },
     {
+      "comment": "Match -- syntax: json inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*json\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.json",
+      "patterns": [
+        {
+          "include": "source.json"
+        }
+      ]
+    },
+    {
       "comment": "Match # yaml inside multiline string",
       "begin": "^\\s*#\\s*yaml\\s*$",
       "beginCaptures": {
@@ -280,6 +360,22 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.yaml",
+      "patterns": [
+        {
+          "include": "source.yaml"
+        }
+      ]
+    },
+    {
+      "comment": "Match -- syntax: yaml inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*yaml\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -339,6 +435,22 @@
       ]
     },
     {
+      "comment": "Match -- syntax: sql inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*sql\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.sql",
+      "patterns": [
+        {
+          "include": "source.sql"
+        }
+      ]
+    },
+    {
       "comment": "Match # lua inside multiline string",
       "begin": "^\\s*#\\s*lua\\s*$",
       "beginCaptures": {
@@ -376,6 +488,22 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.lua",
+      "patterns": [
+        {
+          "include": "source.lua"
+        }
+      ]
+    },
+    {
+      "comment": "Match -- syntax: lua inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*lua\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -435,6 +563,22 @@
       ]
     },
     {
+      "comment": "Match -- syntax: ruby inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*ruby\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.ruby",
+      "patterns": [
+        {
+          "include": "source.ruby"
+        }
+      ]
+    },
+    {
       "comment": "Match # rust inside multiline string",
       "begin": "^\\s*#\\s*rust\\s*$",
       "beginCaptures": {
@@ -472,6 +616,22 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.rust",
+      "patterns": [
+        {
+          "include": "source.rust"
+        }
+      ]
+    },
+    {
+      "comment": "Match -- syntax: rust inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*rust\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -531,6 +691,22 @@
       ]
     },
     {
+      "comment": "Match -- syntax: go inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*go\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.go",
+      "patterns": [
+        {
+          "include": "source.go"
+        }
+      ]
+    },
+    {
       "comment": "Match # html inside multiline string",
       "begin": "^\\s*#\\s*html\\s*$",
       "beginCaptures": {
@@ -568,6 +744,22 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.html",
+      "patterns": [
+        {
+          "include": "text.html.derivative"
+        }
+      ]
+    },
+    {
+      "comment": "Match -- syntax: html inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*html\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",
@@ -627,6 +819,22 @@
       ]
     },
     {
+      "comment": "Match -- syntax: css inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*css\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.css",
+      "patterns": [
+        {
+          "include": "source.css"
+        }
+      ]
+    },
+    {
       "comment": "Match # nix inside multiline string",
       "begin": "^\\s*#\\s*nix\\s*$",
       "beginCaptures": {
@@ -664,6 +872,22 @@
       "beginCaptures": {
         "0": {
           "name": "comment.line.double-slash meta.embedded.hint"
+        }
+      },
+      "while": "^(?!\\s*''(?!'))",
+      "contentName": "meta.embedded.block.nix",
+      "patterns": [
+        {
+          "include": "source.nix"
+        }
+      ]
+    },
+    {
+      "comment": "Match -- syntax: nix inside multiline string",
+      "begin": "^\\s*--\\s*syntax:\\s*nix\\s*$",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.line.double-dash meta.embedded.hint"
         }
       },
       "while": "^(?!\\s*''(?!'))",

--- a/tests/lua-style-comment.test.ts
+++ b/tests/lua-style-comment.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { InjectionGrammar } from "../src/injection-grammar";
+
+describe("Lua-style syntax comments", () => {
+  test("generates an inside-string pattern for -- syntax: lua", () => {
+    const grammar = new InjectionGrammar({ lua: "source.lua" }).toJSON();
+    const pattern = grammar.patterns.find(
+      ({ comment }) =>
+        comment === "Match -- syntax: lua inside multiline string",
+    );
+
+    expect(pattern).toEqual({
+      comment: "Match -- syntax: lua inside multiline string",
+      begin: "^\\s*--\\s*syntax:\\s*lua\\s*$",
+      beginCaptures: {
+        "0": { name: "comment.line.double-dash meta.embedded.hint" },
+      },
+      while: "^(?!\\s*''(?!'))",
+      contentName: "meta.embedded.block.lua",
+      patterns: [{ include: "source.lua" }],
+    });
+  });
+});

--- a/tests/lua-style-comment.test.ts
+++ b/tests/lua-style-comment.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, test } from "bun:test";
 import { InjectionGrammar } from "../src/injection-grammar";
 
 describe("Lua-style syntax comments", () => {
-  test("generates an inside-string pattern for -- syntax: lua", () => {
-    const grammar = new InjectionGrammar({ lua: "source.lua" }).toJSON();
-    const pattern = grammar.patterns.find(
-      ({ comment }) =>
-        comment === "Match -- syntax: lua inside multiline string",
-    );
+  test("generates -- syntax patterns only for languages that use -- comments", () => {
+    const grammar = new InjectionGrammar({
+      lua: "source.lua",
+      sql: "source.sql",
+      shell: "source.shell",
+      javascript: "source.js",
+    }).toJSON();
 
-    expect(pattern).toEqual({
+    expect(findPattern(grammar, "lua")).toEqual({
       comment: "Match -- syntax: lua inside multiline string",
       begin: "^\\s*--\\s*syntax:\\s*lua\\s*$",
       beginCaptures: {
@@ -19,5 +20,20 @@ describe("Lua-style syntax comments", () => {
       contentName: "meta.embedded.block.lua",
       patterns: [{ include: "source.lua" }],
     });
+    expect(findPattern(grammar, "sql")).toMatchObject({
+      begin: "^\\s*--\\s*syntax:\\s*sql\\s*$",
+      patterns: [{ include: "source.sql" }],
+    });
+    expect(findPattern(grammar, "shell")).toBeUndefined();
+    expect(findPattern(grammar, "javascript")).toBeUndefined();
   });
 });
+
+const findPattern = (
+  grammar: ReturnType<InjectionGrammar["toJSON"]>,
+  language: string,
+) =>
+  grammar.patterns.find(
+    ({ comment }) =>
+      comment === `Match -- syntax: ${language} inside multiline string`,
+  );


### PR DESCRIPTION
## Summary

Adds support for `-- syntax: <language>` markers inside Nix multiline strings, limited to languages where `--` is a valid line comment. The built-in generated grammar currently emits this form for Lua and SQL only.

Closes #2.

## Validation

- `bun test tests/lua-style-comment.test.ts`
- `rg 'Match -- syntax' syntaxes/source.nix.injection.tmLanguage.json` shows only SQL and Lua entries
- `bun run lint`
- `bun run format`
- `bun run build`

`bun run type` was also attempted, but it currently fails in dependency type definitions involving `@types/node` and `bun-types`, before extension source type checking completes.
