### PR TITLE
[codex] Fix before-string comment injection

### DIFF
--- a/src/injection-grammar.ts
+++ b/src/injection-grammar.ts
@@ -79,7 +79,7 @@ export class InjectionGrammar {
         beginCaptures: {
           "1": { name: "comment.line.number-sign.nix meta.embedded.hint.nix" },
         },
-        end: "''(?!')",
+        end: "^\\s*''(?!')",
         endCaptures: {
           "0": {
             name: "string.quoted.other.nix punctuation.definition.string.end.nix",
@@ -94,7 +94,7 @@ export class InjectionGrammar {
                 name: "string.quoted.other.nix punctuation.definition.string.begin.nix",
               },
             },
-            end: "(?=''(?!'))",
+            end: "(?=^\\s*''(?!'))",
             contentName: `meta.embedded.block.${primaryId} string.quoted.other.nix`,
             patterns: [{ include: scopeName }],
           },

--- a/syntaxes/source.nix.before-string.injection.tmLanguage.json
+++ b/syntaxes/source.nix.before-string.injection.tmLanguage.json
@@ -10,7 +10,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -25,7 +25,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.shell string.quoted.other.nix",
           "patterns": [
             {
@@ -46,7 +46,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -61,7 +61,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.python string.quoted.other.nix",
           "patterns": [
             {
@@ -82,7 +82,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -97,7 +97,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.javascript string.quoted.other.nix",
           "patterns": [
             {
@@ -118,7 +118,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -133,7 +133,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.typescript string.quoted.other.nix",
           "patterns": [
             {
@@ -154,7 +154,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -169,7 +169,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.json string.quoted.other.nix",
           "patterns": [
             {
@@ -190,7 +190,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -205,7 +205,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.yaml string.quoted.other.nix",
           "patterns": [
             {
@@ -226,7 +226,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -241,7 +241,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.sql string.quoted.other.nix",
           "patterns": [
             {
@@ -262,7 +262,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -277,7 +277,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.lua string.quoted.other.nix",
           "patterns": [
             {
@@ -298,7 +298,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -313,7 +313,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.ruby string.quoted.other.nix",
           "patterns": [
             {
@@ -334,7 +334,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -349,7 +349,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.rust string.quoted.other.nix",
           "patterns": [
             {
@@ -370,7 +370,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -385,7 +385,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.go string.quoted.other.nix",
           "patterns": [
             {
@@ -406,7 +406,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -421,7 +421,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.html string.quoted.other.nix",
           "patterns": [
             {
@@ -442,7 +442,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -457,7 +457,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.css string.quoted.other.nix",
           "patterns": [
             {
@@ -478,7 +478,7 @@
           "name": "comment.line.number-sign.nix meta.embedded.hint.nix"
         }
       },
-      "end": "''(?!')",
+      "end": "^\\s*''(?!')",
       "endCaptures": {
         "0": {
           "name": "string.quoted.other.nix punctuation.definition.string.end.nix"
@@ -493,7 +493,7 @@
               "name": "string.quoted.other.nix punctuation.definition.string.begin.nix"
             }
           },
-          "end": "(?=''(?!'))",
+          "end": "(?=^\\s*''(?!'))",
           "contentName": "meta.embedded.block.nix string.quoted.other.nix",
           "patterns": [
             {

--- a/tests/comment-before-string.test.ts
+++ b/tests/comment-before-string.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { InjectionGrammar } from "../src/injection-grammar";
+
+describe("comment before multiline string", () => {
+  test("keeps the outer pattern open past an assignment string opener", () => {
+    const grammar = new InjectionGrammar({
+      css: "source.css",
+    }).toBeforeStringJSON();
+    const pattern = grammar.patterns.find(
+      ({ comment }) => comment === "Match # syntax: css before a '' string",
+    );
+
+    expect(pattern).toMatchObject({
+      begin: "(#\\s*syntax:\\s*css\\s*)$",
+      end: "^\\s*''(?!')",
+      patterns: [
+        {
+          begin: "''",
+          end: "(?=^\\s*''(?!'))",
+          contentName: "meta.embedded.block.css string.quoted.other.nix",
+          patterns: [{ include: "source.css" }],
+        },
+        { include: "source.nix" },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes before-string `# syntax: <language>` markers so the outer TextMate rule stays open through assignment string openers like `userChrome = ''` and only closes on the multiline string terminator line.

Closes #4.

## Validation

- `bun test tests/comment-before-string.test.ts`
- `bun run lint`
- `bun run format`
- `bun run build`

`bun run type` was also attempted, but it currently fails in dependency type definitions involving `@types/node` and `bun-types`, before extension source type checking completes.
